### PR TITLE
[BACKEND] [SCRUM-15] fix: Add role-based permission checks in admin notes

### DIFF
--- a/apps/admin_notes/views.py
+++ b/apps/admin_notes/views.py
@@ -1,28 +1,68 @@
 from rest_framework import generics, permissions
+from rest_framework.exceptions import PermissionDenied
 from .models import AdminNote
 from .serializers import AdminNoteSerializer
-from apps.users.permissions import IsAdminOrSelf
+from apps.users.permissions import IsAdminOrSuperuser
+
 
 class AdminNoteListCreateView(generics.ListCreateAPIView):
-    queryset = AdminNote.objects.all()
-    serializer_class = AdminNoteSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    """
+    List and create admin notes.
 
-    def perform_create(self, serializer):
-        serializer.save(admin=self.request.user)
-
-class AdminNoteDetailView(generics.RetrieveUpdateDestroyAPIView):
-    queryset = AdminNote.objects.all()
-    serializer_class = AdminNoteSerializer
-    permission_classes = [permissions.IsAuthenticated, IsAdminOrSelf]
-
-class CandidateNotesView(generics.ListAPIView):
+    - GET: Admins/Superusers see all notes; Candidates see only notes about themselves
+    - POST: Only Admins/Superusers can create notes
+    """
     serializer_class = AdminNoteSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
-        candidate_id = self.kwargs['candidate_id']
         user = self.request.user
-        if user.role == 'admin':
-            return AdminNote.objects.filter(candidate_id=candidate_id)
+        # Admins and Superusers can see all notes
+        if user.role in ['admin', 'superuser']:
+            return AdminNote.objects.all()
+        # Candidates can only see notes about themselves
         return AdminNote.objects.filter(candidate=user)
+
+    def perform_create(self, serializer):
+        # Only admins and superusers can create notes
+        if self.request.user.role not in ['admin', 'superuser']:
+            raise PermissionDenied("Only admins can create notes.")
+        serializer.save(admin=self.request.user)
+
+
+class AdminNoteDetailView(generics.RetrieveUpdateDestroyAPIView):
+    """
+    Retrieve, update, or delete an admin note.
+
+    - Admins/Superusers can access any note
+    - Candidates can only view notes about themselves (read-only)
+    """
+    serializer_class = AdminNoteSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        user = self.request.user
+        if user.role in ['admin', 'superuser']:
+            return AdminNote.objects.all()
+        # Candidates can only see notes about themselves
+        return AdminNote.objects.filter(candidate=user)
+
+    def check_object_permissions(self, request, obj):
+        super().check_object_permissions(request, obj)
+        # Candidates cannot modify notes, only view
+        if request.user.role == 'candidate' and request.method not in permissions.SAFE_METHODS:
+            raise PermissionDenied("Candidates cannot modify admin notes.")
+
+
+class CandidateNotesView(generics.ListAPIView):
+    """
+    List all notes for a specific candidate.
+
+    - Only Admins/Superusers can access this endpoint
+    """
+    serializer_class = AdminNoteSerializer
+    permission_classes = [permissions.IsAuthenticated, IsAdminOrSuperuser]
+
+    def get_queryset(self):
+        candidate_id = self.kwargs['candidate_id']
+        return AdminNote.objects.filter(candidate_id=candidate_id)


### PR DESCRIPTION
## 🎯 Ticket
[SCRUM-15](https://capaciti-pss-team.atlassian.net/browse/SCRUM-15)

## 📋 Summary
Fix authorization bypass vulnerability in admin notes endpoints. Previously any authenticated user could view ALL admin notes and create notes without proper role checks.

## 🔄 Changes Made
- [x] **AdminNoteListCreateView**: 
  - GET: Admins/Superusers see all notes; Candidates only see notes about themselves
  - POST: Only Admins/Superusers can create notes (raises PermissionDenied)
- [x] **AdminNoteDetailView**:
  - Role-filtered queryset prevents unauthorized access
  - Candidates can view (not modify) notes about themselves
- [x] **CandidateNotesView**:
  - Restricted to Admins/Superusers only using `IsAdminOrSuperuser` permission class

## 🗄️ Database Changes
- [x] No database changes required
- [x] No migrations needed

## ✅ Testing Done
- [x] Verified permission logic in code review
- [x] Tested syntax compiles correctly

## 🔒 Security Checklist
- [x] Permission checks added to all endpoints
- [x] Role-based access control implemented
- [x] Candidates cannot access other users notes
- [x] Candidates cannot create/modify/delete notes

## 🔐 POPIA Compliance
- [x] Access controls properly configured
- [x] Users can only see data they are authorized to view
- [x] Admin notes about candidates protected from unauthorized access

## 🚦 Acceptance Criteria Met
- [x] Only admins can create notes
- [x] Candidates can only see their own notes
- [x] Admins can see all notes
- [x] CandidateNotesView restricted to admin/superuser

## ⚠️ Breaking Changes
None - this is a security fix that restricts previously over-permissive behavior.

## 💬 Additional Notes
- This was a **CRITICAL** security vulnerability
- Sensitive admin notes about candidates were exposed to all authenticated users
- Now properly enforces role-based access control

Refs: SCRUM-15

[SCRUM-15]: https://capaciti-pss-team.atlassian.net/browse/SCRUM-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ