### PR TITLE
[BACKEND] [SCRUM-16] fix: Make SECRET_KEY mandatory with validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,53 @@
-# Django Settings
-SECRET_KEY=your-secret-key-here-replace-with-secure-random-string
-DEBUG=False
-PYTHON_VERSION=3.11.9
+# =============================================================================
+# PSS Backend Environment Configuration
+# =============================================================================
+# Copy this file to .env and fill in your values
+# NEVER commit .env to version control
 
-# Hosts (Update with your actual domains)
-ALLOWED_HOSTS=127.0.0.1,localhost,your-app.onrender.com
-CORS_ALLOWED_ORIGINS=http://localhost:5173,https://pss-frontend-ebon.vercel.app
+# -----------------------------------------------------------------------------
+# Django Core Settings
+# -----------------------------------------------------------------------------
+
+# SECRET_KEY (REQUIRED - Django will not start without this!)
+# Generate with: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+# Must be at least 50 characters and unique per environment
+SECRET_KEY=
+
+# Set to False in production (default: False)
+DEBUG=False
+
+# -----------------------------------------------------------------------------
+# Host Configuration
+# -----------------------------------------------------------------------------
+# Your server domain/IP addresses (comma-separated)
+ALLOWED_HOSTS=localhost,127.0.0.1,your-domain.com
+
+# Frontend origins for CORS (comma-separated)
+CORS_ALLOWED_ORIGINS=http://localhost:5173,https://your-domain.com
 CORS_ALLOW_ALL_ORIGINS=False
 
-# Database Configuration (Render will auto-populate these)
-DB_NAME=pss_database
-DB_USER=your_db_user
-DB_PASSWORD=your_db_password
+# -----------------------------------------------------------------------------
+# Database Configuration (PostgreSQL)
+# -----------------------------------------------------------------------------
+DB_NAME=pss_backend
+DB_USER=pss_user
+DB_PASSWORD=your-db-password
 DB_HOST=localhost
 DB_PORT=5432
-DB_SSL=true
+DB_SSL=False
 
+# -----------------------------------------------------------------------------
+# PII Encryption Key (POPIA Compliance)
+# -----------------------------------------------------------------------------
+# CRITICAL: Generate a unique key and store it securely
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# WARNING: Losing this key means losing access to encrypted data!
+FIELD_ENCRYPTION_KEY=
+
+# -----------------------------------------------------------------------------
 # Security Settings (Production)
+# -----------------------------------------------------------------------------
+# Enable these when running behind HTTPS/Nginx
 SECURE_SSL_REDIRECT=True
 CSRF_COOKIE_SECURE=True
 SESSION_COOKIE_SECURE=True
@@ -24,11 +55,12 @@ SECURE_HSTS_SECONDS=31536000
 SECURE_HSTS_INCLUDE_SUBDOMAINS=True
 SECURE_HSTS_PRELOAD=True
 
-# Development overrides (uncomment for local development)
+# -----------------------------------------------------------------------------
+# Development Overrides
+# -----------------------------------------------------------------------------
+# Uncomment these for local development without HTTPS
 # DEBUG=True
 # SECURE_SSL_REDIRECT=False
 # CSRF_COOKIE_SECURE=False
 # SESSION_COOKIE_SECURE=False
 # SECURE_HSTS_SECONDS=0
-# SECURE_HSTS_INCLUDE_SUBDOMAINS=False
-# SECURE_HSTS_PRELOAD=False

--- a/pss_backend/settings.py
+++ b/pss_backend/settings.py
@@ -4,17 +4,78 @@ AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
 ]
 import os
+import sys
 from pathlib import Path
 from datetime import timedelta
-from decouple import config, Csv
+from decouple import config, Csv, UndefinedValueError
 
 # Build paths inside the project
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-# Security settings
-SECRET_KEY = config('SECRET_KEY', default='django-insecure-development-key-only-for-testing')
-DEBUG = config('DEBUG', cast=bool, default=True)
-ALLOWED_HOSTS = config('ALLOWED_HOSTS', cast=Csv(), default='*')
+# =============================================================================
+# SECRET_KEY Configuration (CRITICAL SECURITY)
+# =============================================================================
+# SECRET_KEY is MANDATORY - Django will not start without it.
+# Generate with: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+
+# List of known insecure/default keys that must be rejected
+INSECURE_SECRET_KEYS = [
+    'django-insecure-development-key-only-for-testing',
+    'your-secret-key-here',
+    'change-me',
+    'secret',
+    'django-insecure',
+]
+
+try:
+    SECRET_KEY = config('SECRET_KEY')
+except UndefinedValueError:
+    raise RuntimeError(
+        "\n\n"
+        "=" * 70 + "\n"
+        "CRITICAL ERROR: SECRET_KEY is not set!\n"
+        "=" * 70 + "\n\n"
+        "Django requires a SECRET_KEY to run securely.\n\n"
+        "To fix this:\n"
+        "1. Generate a key: python -c \"from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())\"\n"
+        "2. Add to your .env file: SECRET_KEY=your-generated-key\n\n"
+        "WARNING: Never commit your SECRET_KEY to version control!\n"
+        "=" * 70 + "\n"
+    )
+
+# Validate SECRET_KEY
+def _validate_secret_key(key):
+    """Validate that SECRET_KEY meets security requirements."""
+    errors = []
+
+    # Check minimum length (Django recommends at least 50 characters)
+    if len(key) < 50:
+        errors.append(f"SECRET_KEY is too short ({len(key)} chars). Must be at least 50 characters.")
+
+    # Check against known insecure keys
+    if key.lower() in [k.lower() for k in INSECURE_SECRET_KEYS] or 'insecure' in key.lower():
+        errors.append("SECRET_KEY contains a known insecure/default value.")
+
+    if errors:
+        raise RuntimeError(
+            "\n\n"
+            "=" * 70 + "\n"
+            "CRITICAL ERROR: SECRET_KEY validation failed!\n"
+            "=" * 70 + "\n\n"
+            + "\n".join(f"  - {e}" for e in errors) + "\n\n"
+            "To fix this:\n"
+            "1. Generate a new key: python -c \"from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())\"\n"
+            "2. Update your .env file with the new key\n\n"
+            "=" * 70 + "\n"
+        )
+
+_validate_secret_key(SECRET_KEY)
+
+# =============================================================================
+# Core Django Settings
+# =============================================================================
+DEBUG = config('DEBUG', cast=bool, default=False)
+ALLOWED_HOSTS = config('ALLOWED_HOSTS', cast=Csv(), default='localhost,127.0.0.1')
 
 # Application definition
 INSTALLED_APPS = [


### PR DESCRIPTION
## 🎯 Ticket
[SCRUM-16](https://capaciti-pss-team.atlassian.net/browse/SCRUM-16)

## 📋 Summary
Fix critical security vulnerability where SECRET_KEY had a hardcoded default value. Django now fails to start without a valid SECRET_KEY, preventing session hijacking and CSRF token prediction attacks.

## 🔄 Changes Made
- [x] Removed insecure default SECRET_KEY value
- [x] Django now fails to start if SECRET_KEY is missing
- [x] Added SECRET_KEY validation function:
  - Minimum 50 character length requirement
  - Rejects known insecure/default values (e.g., "django-insecure", "your-secret-key-here")
- [x] Clear error messages with generation instructions
- [x] Fixed other insecure defaults:
  - DEBUG now defaults to `False` (was `True`)
  - ALLOWED_HOSTS now defaults to `localhost,127.0.0.1` (was `*`)
- [x] Updated `.env.example` with proper documentation

## 🗄️ Database Changes
- [x] No database changes required
- [x] No migrations needed

## ✅ Testing Done
- [x] Verified Django fails to start without SECRET_KEY
- [x] Verified validation rejects short keys
- [x] Verified validation rejects known insecure keys
- [x] Verified Django starts with valid SECRET_KEY

## 🔒 Security Checklist
- [x] No hardcoded secrets in code
- [x] SECRET_KEY must be provided via environment
- [x] Validation prevents weak/default keys
- [x] DEBUG defaults to False (production-safe)
- [x] ALLOWED_HOSTS restricted by default

## 🔐 POPIA Compliance
- [x] Secure session management (requires strong SECRET_KEY)
- [x] CSRF protection properly configured
- [x] No default credentials that could be exploited

## 🚦 Acceptance Criteria Met
- [x] SECRET_KEY is mandatory (no default)
- [x] Minimum length validation (50 chars)
- [x] Rejects known insecure values
- [x] Clear error messages for developers
- [x] Generation command documented

## ⚠️ Breaking Changes
- **SECRET_KEY is now required** - Existing deployments MUST have a valid SECRET_KEY in `.env`
- Generate with: `python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"`
- **DEBUG defaults to False** - Set `DEBUG=True` explicitly for development
- **ALLOWED_HOSTS restricted** - Update `.env` with your domain

## 💬 Additional Notes
- This was a **CRITICAL** security vulnerability
- If default key was used in production, sessions should be invalidated
- Rotate SECRET_KEY immediately if compromise is suspected

Refs: SCRUM-16

[SCRUM-16]: https://capaciti-pss-team.atlassian.net/browse/SCRUM-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ