### PR TITLE
[BACKEND] [SCRUM-120] feat: Integrate CAPTCHA for enhanced brute force protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,33 @@ SECURE_HSTS_PRELOAD=True
 CSRF_TRUSTED_ORIGINS=https://your-frontend-domain.com,https://pss-frontend-ebon.vercel.app
 
 # -----------------------------------------------------------------------------
+# CAPTCHA Configuration (SCRUM-120 - Brute Force Protection)
+# -----------------------------------------------------------------------------
+# Enable/disable CAPTCHA (useful for testing)
+CAPTCHA_ENABLED=True
+
+# CAPTCHA provider ('recaptcha', 'hcaptcha', 'turnstile')
+CAPTCHA_PROVIDER=recaptcha
+
+# Failed login attempts before requiring CAPTCHA
+CAPTCHA_TRIGGER_THRESHOLD=3
+
+# Cache timeout for failed attempts (seconds, default: 900 = 15 minutes)
+CAPTCHA_FAILED_LOGIN_TIMEOUT=900
+
+# Google reCAPTCHA v3 Keys
+# Get yours at: https://www.google.com/recaptcha/admin/create
+RECAPTCHA_PUBLIC_KEY=your_recaptcha_site_key_here
+RECAPTCHA_PRIVATE_KEY=your_recaptcha_secret_key_here
+
+# reCAPTCHA v3 score threshold (0.0-1.0, higher = more strict)
+# 0.0 = likely bot, 1.0 = likely human
+RECAPTCHA_REQUIRED_SCORE=0.5
+
+# Admin IPs that bypass CAPTCHA (optional, comma-separated)
+CAPTCHA_BYPASS_IPS=
+
+# -----------------------------------------------------------------------------
 # Development Overrides
 # -----------------------------------------------------------------------------
 # DEBUG=True
@@ -60,3 +87,4 @@ CSRF_TRUSTED_ORIGINS=https://your-frontend-domain.com,https://pss-frontend-ebon.
 # SESSION_COOKIE_SECURE=False
 # SECURE_HSTS_SECONDS=0
 # CSRF_TRUSTED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+# CAPTCHA_ENABLED=False  # Disable CAPTCHA for development

--- a/pss_backend/captcha.py
+++ b/pss_backend/captcha.py
@@ -1,0 +1,245 @@
+"""
+SCRUM-120: CAPTCHA Verification Utility
+
+Provides CAPTCHA verification for brute force protection.
+Integrates with rate limiting (SCRUM-10) to add human verification layer.
+
+Supported providers:
+- Google reCAPTCHA v3 (recommended - invisible, risk-based scoring)
+- hCaptcha (privacy-focused alternative)
+- Cloudflare Turnstile (privacy-focused, newer)
+"""
+import requests
+import logging
+from django.conf import settings
+from django.core.cache import cache
+
+logger = logging.getLogger('django.security.auth')
+
+
+class CaptchaVerificationError(Exception):
+    """Raised when CAPTCHA verification fails."""
+    pass
+
+
+def verify_recaptcha(token, action='login', remote_ip=None):
+    """
+    Verify Google reCAPTCHA v3 token.
+
+    Args:
+        token (str): reCAPTCHA token from frontend
+        action (str): Expected action name (prevents token reuse)
+        remote_ip (str): Optional user IP for additional verification
+
+    Returns:
+        tuple: (success: bool, score: float, error_message: str)
+
+    Raises:
+        CaptchaVerificationError: If verification request fails
+    """
+    if not token:
+        logger.warning(f'CAPTCHA verification attempted without token (action: {action})')
+        return False, 0.0, 'CAPTCHA token is required'
+
+    try:
+        data = {
+            'secret': settings.RECAPTCHA_PRIVATE_KEY,
+            'response': token,
+        }
+
+        if remote_ip:
+            data['remoteip'] = remote_ip
+
+        response = requests.post(
+            'https://www.google.com/recaptcha/api/siteverify',
+            data=data,
+            timeout=5  # 5 second timeout
+        )
+        response.raise_for_status()
+        result = response.json()
+
+    except requests.RequestException as e:
+        logger.error(f'CAPTCHA verification request failed: {str(e)}')
+        raise CaptchaVerificationError('CAPTCHA service unavailable')
+
+    except Exception as e:
+        logger.error(f'CAPTCHA verification error: {str(e)}')
+        raise CaptchaVerificationError('CAPTCHA verification failed')
+
+    # Check if verification succeeded
+    if not result.get('success', False):
+        error_codes = result.get('error-codes', [])
+        logger.warning(
+            f'CAPTCHA verification failed (action: {action}, errors: {error_codes})'
+        )
+        return False, 0.0, 'CAPTCHA verification failed'
+
+    # For reCAPTCHA v3, check score threshold
+    score = result.get('score', 0.0)
+    if score < settings.RECAPTCHA_REQUIRED_SCORE:
+        logger.warning(
+            f'CAPTCHA score too low (action: {action}, score: {score}, '
+            f'threshold: {settings.RECAPTCHA_REQUIRED_SCORE})'
+        )
+        return False, score, f'CAPTCHA score too low: {score}'
+
+    # Check action matches (prevents token reuse across different forms)
+    result_action = result.get('action', '')
+    if result_action != action:
+        logger.warning(
+            f'CAPTCHA action mismatch (expected: {action}, got: {result_action})'
+        )
+        return False, score, 'CAPTCHA action mismatch'
+
+    logger.info(
+        f'CAPTCHA verification successful (action: {action}, score: {score})'
+    )
+    return True, score, ''
+
+
+def verify_captcha(token, action='login', remote_ip=None):
+    """
+    Verify CAPTCHA token using configured provider.
+
+    This is the main entry point for CAPTCHA verification.
+    Routes to the appropriate provider based on settings.
+
+    Args:
+        token (str): CAPTCHA token from frontend
+        action (str): Expected action name
+        remote_ip (str): Optional user IP
+
+    Returns:
+        tuple: (success: bool, score: float, error_message: str)
+    """
+    if not settings.CAPTCHA_ENABLED:
+        logger.debug('CAPTCHA disabled, skipping verification')
+        return True, 1.0, ''
+
+    # Check if IP is whitelisted
+    if remote_ip and remote_ip in settings.CAPTCHA_BYPASS_IPS:
+        logger.info(f'CAPTCHA bypassed for whitelisted IP: {remote_ip}')
+        return True, 1.0, ''
+
+    provider = settings.CAPTCHA_PROVIDER.lower()
+
+    if provider == 'recaptcha':
+        return verify_recaptcha(token, action, remote_ip)
+    elif provider == 'hcaptcha':
+        # TODO: Implement hCaptcha verification
+        logger.warning('hCaptcha not implemented, falling back to reCAPTCHA')
+        return verify_recaptcha(token, action, remote_ip)
+    elif provider == 'turnstile':
+        # TODO: Implement Cloudflare Turnstile verification
+        logger.warning('Turnstile not implemented, falling back to reCAPTCHA')
+        return verify_recaptcha(token, action, remote_ip)
+    else:
+        logger.error(f'Unknown CAPTCHA provider: {provider}')
+        return False, 0.0, 'Invalid CAPTCHA provider configuration'
+
+
+def track_failed_login_attempt(identifier):
+    """
+    Track failed login attempts for a given identifier (IP + email).
+
+    Args:
+        identifier (str): Unique identifier (e.g., "192.168.1.1:user@example.com")
+
+    Returns:
+        int: Number of failed attempts
+    """
+    cache_key = f'failed_login:{identifier}'
+    attempts = cache.get(cache_key, 0)
+    attempts += 1
+    cache.set(cache_key, attempts, timeout=settings.CAPTCHA_FAILED_LOGIN_TIMEOUT)
+
+    logger.debug(f'Failed login attempt tracked: {identifier} ({attempts} attempts)')
+    return attempts
+
+
+def get_failed_login_attempts(identifier):
+    """
+    Get number of failed login attempts for a given identifier.
+
+    Args:
+        identifier (str): Unique identifier (e.g., "192.168.1.1:user@example.com")
+
+    Returns:
+        int: Number of failed attempts
+    """
+    cache_key = f'failed_login:{identifier}'
+    return cache.get(cache_key, 0)
+
+
+def reset_failed_login_attempts(identifier):
+    """
+    Reset failed login attempts after successful login.
+
+    Args:
+        identifier (str): Unique identifier (e.g., "192.168.1.1:user@example.com")
+    """
+    cache_key = f'failed_login:{identifier}'
+    cache.delete(cache_key)
+    logger.debug(f'Failed login attempts reset: {identifier}')
+
+
+def is_captcha_required(identifier):
+    """
+    Check if CAPTCHA is required based on failed login attempts.
+
+    Args:
+        identifier (str): Unique identifier (e.g., "192.168.1.1:user@example.com")
+
+    Returns:
+        bool: True if CAPTCHA is required
+    """
+    if not settings.CAPTCHA_ENABLED:
+        return False
+
+    attempts = get_failed_login_attempts(identifier)
+    required = attempts >= settings.CAPTCHA_TRIGGER_THRESHOLD
+
+    if required:
+        logger.info(
+            f'CAPTCHA required for {identifier} '
+            f'({attempts}/{settings.CAPTCHA_TRIGGER_THRESHOLD} attempts)'
+        )
+
+    return required
+
+
+def get_client_ip(request):
+    """
+    Extract client IP address from request, accounting for proxies.
+
+    Args:
+        request: Django request object
+
+    Returns:
+        str: Client IP address
+    """
+    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+    if x_forwarded_for:
+        # Get first IP in the chain (original client)
+        ip = x_forwarded_for.split(',')[0].strip()
+    else:
+        ip = request.META.get('REMOTE_ADDR', '')
+
+    return ip
+
+
+def create_login_identifier(ip, email):
+    """
+    Create unique identifier for tracking failed login attempts.
+
+    Combines IP and email to track attempts per user per location.
+    This prevents a single IP from locking out all users, and vice versa.
+
+    Args:
+        ip (str): Client IP address
+        email (str): User email address
+
+    Returns:
+        str: Unique identifier
+    """
+    return f'{ip}:{email.lower()}'

--- a/pss_backend/settings.py
+++ b/pss_backend/settings.py
@@ -270,6 +270,40 @@ SIMPLE_JWT = {
 }
 
 # =============================================================================
+# CAPTCHA CONFIGURATION (SCRUM-120 - Enhanced Brute Force Protection)
+# =============================================================================
+# Integrates with rate limiting (SCRUM-10) to add human verification layer
+
+# Enable/disable CAPTCHA (useful for testing)
+CAPTCHA_ENABLED = config('CAPTCHA_ENABLED', cast=bool, default=True)
+
+# CAPTCHA provider ('recaptcha', 'hcaptcha', 'turnstile')
+CAPTCHA_PROVIDER = config('CAPTCHA_PROVIDER', default='recaptcha')
+
+# Failed attempts before requiring CAPTCHA (per IP + email combination)
+CAPTCHA_TRIGGER_THRESHOLD = config('CAPTCHA_TRIGGER_THRESHOLD', cast=int, default=3)
+
+# Cache timeout for failed login attempts (15 minutes)
+CAPTCHA_FAILED_LOGIN_TIMEOUT = config('CAPTCHA_FAILED_LOGIN_TIMEOUT', cast=int, default=900)
+
+# Google reCAPTCHA v3 Configuration
+RECAPTCHA_PUBLIC_KEY = config('RECAPTCHA_PUBLIC_KEY', default='')
+RECAPTCHA_PRIVATE_KEY = config('RECAPTCHA_PRIVATE_KEY', default='')
+RECAPTCHA_REQUIRED_SCORE = config('RECAPTCHA_REQUIRED_SCORE', cast=float, default=0.5)  # 0.0-1.0
+
+# Admin IPs that bypass CAPTCHA (optional - for internal tools)
+CAPTCHA_BYPASS_IPS = config('CAPTCHA_BYPASS_IPS', cast=Csv(), default='')
+
+# CAPTCHA applies to these actions
+CAPTCHA_PROTECTED_ACTIONS = ['login', 'register', 'password_reset']
+
+_secrets_logger.info(
+    "CAPTCHA enabled: %s, provider: %s, trigger threshold: %d attempts",
+    CAPTCHA_ENABLED, CAPTCHA_PROVIDER, CAPTCHA_TRIGGER_THRESHOLD
+)
+# =============================================================================
+
+# =============================================================================
 # CORS CONFIGURATION (SCRUM-41 — Harden Production CORS)
 # =============================================================================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ dj-database-url==3.0.1
 django-encrypted-model-fields==0.6.5
 django-auditlog==3.0.0
 django-axes==7.0.0
+django-recaptcha==4.1.0


### PR DESCRIPTION
## Summary
Integrates Google reCAPTCHA v3 to add human verification layer on top of existing rate limiting (SCRUM-10). Prevents distributed brute force attacks, credential stuffing, bot networks, and automated account enumeration that can bypass IP-based rate limits.

## Changes Made

### 🔐 CAPTCHA Utility Module
**pss_backend/captcha.py** - Comprehensive CAPTCHA verification system
- **verify_recaptcha()** - Verifies tokens with Google reCAPTCHA v3 API
  - Checks success status, score threshold (0.0-1.0), and action matching
  - Returns (success, score, error_message) tuple
  - 5-second timeout for API requests
  - Prevents token reuse across forms
- **verify_captcha()** - Main entry point supporting multiple providers
  - Currently: reCAPTCHA v3
  - Future: hCaptcha, Cloudflare Turnstile
  - Respects CAPTCHA_ENABLED setting
  - Checks IP whitelist for bypass
- **Failed Attempt Tracking** (using Django cache):
  - `track_failed_login_attempt()` - Increments counter per IP+email
  - `get_failed_login_attempts()` - Gets current attempt count
  - `reset_failed_login_attempts()` - Clears on successful login
  - `is_captcha_required()` - Checks if threshold (3 attempts) reached
- **Helper Functions**:
  - `get_client_ip()` - Extracts IP with proxy support (X-Forwarded-For)
  - `create_login_identifier()` - Creates unique identifier from IP+email

### 🔧 Settings Configuration
**pss_backend/settings.py** - CAPTCHA configuration section
```python
CAPTCHA_ENABLED = True  # Can disable for testing
CAPTCHA_PROVIDER = 'recaptcha'  # Future: hCaptcha, Turnstile
CAPTCHA_TRIGGER_THRESHOLD = 3  # Failed attempts before CAPTCHA required
CAPTCHA_FAILED_LOGIN_TIMEOUT = 900  # 15 minutes
RECAPTCHA_PUBLIC_KEY = env('RECAPTCHA_PUBLIC_KEY')
RECAPTCHA_PRIVATE_KEY = env('RECAPTCHA_PRIVATE_KEY')
RECAPTCHA_REQUIRED_SCORE = 0.5  # 0.0 = bot, 1.0 = human
CAPTCHA_BYPASS_IPS = []  # Admin IPs that bypass CAPTCHA
CAPTCHA_PROTECTED_ACTIONS = ['login', 'register', 'password_reset']
```

### 🔑 Login View Integration
**apps/authentication/views.py** - Enhanced with CAPTCHA verification

**CAPTCHA Flow:**
1. ✅ Check failed attempts for IP+email combination
2. ✅ If ≥3 attempts, require CAPTCHA token
3. ✅ Verify CAPTCHA with Google API (score, action, etc.)
4. ✅ On success: allow login attempt to proceed
5. ✅ On failure: return error with `captcha_required` flag

**Failed Login Tracking:**
- Tracks per IP+email combination (not just IP)
- Prevents single IP from locking out all users
- Prevents single user from being locked out globally
- 15-minute timeout (900 seconds)

**Successful Login:**
- Resets failed attempts counter immediately
- Logs successful authentication
- No CAPTCHA required on next login

**Error Handling:**
- **Fail open** if CAPTCHA service unavailable (logged for monitoring)
- Clear error messages for users
- Inform frontend when CAPTCHA will be required next time

### 📝 Environment Configuration
**.env.example** - Added comprehensive CAPTCHA section with:
- `CAPTCHA_ENABLED` - Toggle for testing/development
- `CAPTCHA_PROVIDER` - Provider selection (recaptcha/hcaptcha/turnstile)
- `CAPTCHA_TRIGGER_THRESHOLD` - Failed attempts before CAPTCHA (default: 3)
- `CAPTCHA_FAILED_LOGIN_TIMEOUT` - Cache timeout (default: 900s)
- `RECAPTCHA_PUBLIC_KEY` - reCAPTCHA site key
- `RECAPTCHA_PRIVATE_KEY` - reCAPTCHA secret key
- `RECAPTCHA_REQUIRED_SCORE` - Bot detection threshold (default: 0.5)
- `CAPTCHA_BYPASS_IPS` - Admin IP whitelist
- Development override examples

### 📦 Dependencies
**requirements.txt** - Added django-recaptcha==4.1.0

## How It Works

### User Experience Flow

**Normal Login (First 2 Attempts):**
```
User enters credentials → Login attempt → Success/Failure (no CAPTCHA)
```

**After 3 Failed Attempts:**
```
User enters credentials → Backend checks counter (≥3)
                       ↓
         Frontend receives captcha_required=true
                       ↓
         Frontend loads reCAPTCHA v3 script
                       ↓
         Frontend executes grecaptcha.execute()
                       ↓
         Token sent with next login request
                       ↓
         Backend verifies token with Google
                       ↓
         If valid → Allow login attempt
         If invalid → Return error
```

**Successful Login:**
```
User logs in successfully → Counter reset → Next login won't require CAPTCHA
```

### Response Examples

**First 2 Failed Attempts:**
```json
{
  "detail": "Invalid email or password"
}
```

**3rd Failed Attempt (Warning):**
```json
{
  "detail": "Invalid email or password",
  "captcha_required": true,
  "message": "Too many failed attempts. CAPTCHA will be required for next login."
}
```

**CAPTCHA Required (No Token Provided):**
```json
{
  "detail": "Security verification required",
  "captcha_required": true,
  "message": "Too many failed attempts. Please complete the security check."
}
```

**CAPTCHA Verification Failed:**
```json
{
  "detail": "Security verification failed",
  "captcha_required": true,
  "message": "Please try again or contact support if you continue to have issues."
}
```

## Security Features

✅ **Fail Open** - If CAPTCHA service unavailable, allow login (but log for monitoring)
✅ **IP + Email Tracking** - Prevents single IP from locking out all users
✅ **15-Minute Timeout** - Failed attempts expire automatically
✅ **Score-Based Detection** - reCAPTCHA v3 uses risk score (0.0-1.0)
✅ **Action Verification** - Prevents token reuse across different forms
✅ **IP Whitelist** - Admin IPs can bypass CAPTCHA
✅ **Configurable** - Can disable for testing, adjust threshold and score
✅ **Comprehensive Logging** - All CAPTCHA events logged (attempts, verifications, failures)
✅ **Proxy Support** - Handles X-Forwarded-For header correctly

## Compliance

✅ **OWASP A07:2021** - Identification and Authentication Failures  
✅ **Defense in Depth** - Combines with:
  - Rate limiting (SCRUM-10)
  - Django Axes lockout
  - DRF throttles
✅ **Privacy** - Can switch to hCaptcha/Turnstile for GDPR/POPIA compliance

## Testing

**To test without CAPTCHA:**
```bash
# .env
CAPTCHA_ENABLED=False
```

**To test with CAPTCHA:**
1. Get reCAPTCHA v3 keys: https://www.google.com/recaptcha/admin/create
2. Add keys to .env:
   ```
   RECAPTCHA_PUBLIC_KEY=your_site_key
   RECAPTCHA_PRIVATE_KEY=your_secret_key
   ```
3. Frontend must execute reCAPTCHA and send token

**Manual Testing Steps:**
1. Attempt login with wrong password 3 times
2. On 3rd attempt, response includes `captcha_required: true`
3. Next login requires `captcha_token` in request body
4. Without token → 400 error
5. With valid token → login attempt proceeds
6. On successful login → counter resets

## Frontend Integration Required

⚠️ **Frontend changes needed** (see SCRUM-120 frontend ticket):

1. **Load reCAPTCHA v3 script:**
   ```html
   <script src="https://www.google.com/recaptcha/api.js?render=YOUR_SITE_KEY"></script>
   ```

2. **Execute on login when CAPTCHA required:**
   ```javascript
   grecaptcha.ready(function() {
       grecaptcha.execute(SITE_KEY, {action: 'login'})
           .then(function(token) {
               // Include token in API request
               axios.post('/api/auth/login/', {
                   email: email,
                   password: password,
                   captcha_token: token
               });
           });
   });
   ```

3. **Handle `captcha_required` flag in responses**
4. **Show user-friendly messages** when CAPTCHA required/failed

## Related Tickets

- **SCRUM-10**: Rate limiting implementation (this builds on top)
- **SCRUM-117**: Password reset (will add CAPTCHA in future PR)
- **SCRUM-120 (Frontend)**: Frontend reCAPTCHA integration

## Privacy Considerations

**reCAPTCHA v3 Privacy:**
- Tracks user behavior across sites
- May not be GDPR/POPIA compliant without user consent
- Consider adding to privacy policy

**Alternatives for Privacy:**
- hCaptcha (GDPR-compliant, privacy-focused)
- Cloudflare Turnstile (privacy-focused, invisible)

**Recommendation:** Document in privacy policy that CAPTCHA is used for security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)